### PR TITLE
Context-dependent literal interpretation + type checker

### DIFF
--- a/gallium-live/src/Editor.js
+++ b/gallium-live/src/Editor.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { parseTopLevel } from "gallium/lib/parser";
 import { type ABT, resolve } from "gallium/lib/resolver";
-import * as TopLevel from "./top_level";
+import * as TopLevel from "gallium/lib/top_level";
 import { silence } from "gallium/lib/semantics";
 import { OutputSelector } from "./OutputSelector";
 import * as MIDI from "./midi";

--- a/gallium-live/src/Editor.js
+++ b/gallium-live/src/Editor.js
@@ -3,7 +3,6 @@ import * as React from "react";
 import styled from "styled-components";
 import { parseTopLevel } from "gallium/lib/parser";
 import { type ABT, resolve } from "gallium/lib/resolver";
-import * as Interpreter from "gallium/lib/interpreter";
 import * as TopLevel from "./top_level";
 import { silence } from "gallium/lib/semantics";
 import { OutputSelector } from "./OutputSelector";
@@ -27,7 +26,6 @@ const mapStateToProps = ({ text, invert }) => ({ text, invert });
 
 type State = {
   text: string,
-  abt: ?ABT,
   error: ?string,
   isInitialized: boolean
 };
@@ -41,7 +39,6 @@ export class _Editor extends React.Component<
     this.state = {
       text: props.text,
       error: undefined,
-      abt: undefined,
       isInitialized: false
     };
   }
@@ -69,12 +66,10 @@ export class _Editor extends React.Component<
     try {
       const abt = TopLevel.parseAndResolve(text);
       this.setState({
-        abt,
         error: undefined
       });
       this.props.dispatch(store => {
-        const patternTransformer = Interpreter.interpret(abt);
-        store.state.pattern = patternTransformer(silence);
+        store.state.pattern = TopLevel.interpret(abt);
       });
       LocalStorage.saveText(text);
     } catch (e) {

--- a/gallium-live/src/playback.test.js
+++ b/gallium-live/src/playback.test.js
@@ -6,6 +6,10 @@ import * as Playback from "./playback";
 import { Store, makeInitialState } from "./efx";
 import * as TopLevel from "./top_level";
 
+function parseAndInterpret(code: string) {
+  return TopLevel.interpret(TopLevel.parseAndResolve(code));
+}
+
 describe("playback", () => {
   let store: Store;
   beforeEach(() => {
@@ -15,7 +19,7 @@ describe("playback", () => {
   it("registers a noteOn and then a noteOff", async () => {
     TestUtils.mockPerformanceNow(0);
 
-    const pattern = TopLevel.interpret("note 60");
+    const pattern = parseAndInterpret("note 60");
     const events = await store.dispatch(
       collectEventsNRT({ numBeats: 1, pattern })
     );
@@ -32,7 +36,7 @@ describe("playback", () => {
   });
 
   it("repeats patterns", async () => {
-    const pattern = TopLevel.interpret("note 60");
+    const pattern = parseAndInterpret("note 60");
 
     {
       TestUtils.mockPerformanceNow(0);
@@ -71,7 +75,7 @@ describe("playback", () => {
   });
 
   it("wraps MIDI note values over 127", async () => {
-    const pattern = TopLevel.interpret("note 128");
+    const pattern = parseAndInterpret("note 128");
     const events = await store.dispatch(
       collectEventsNRT({ numBeats: 1, pattern })
     );
@@ -80,7 +84,7 @@ describe("playback", () => {
   });
 
   it("wraps negative MIDI note values", async () => {
-    const pattern = TopLevel.interpret("do (note 0) (sub 12)");
+    const pattern = parseAndInterpret("do (note 0) (sub 12)");
     const events = await store.dispatch(
       collectEventsNRT({ numBeats: 1, pattern })
     );

--- a/gallium-live/src/playback.test.js
+++ b/gallium-live/src/playback.test.js
@@ -4,7 +4,7 @@ import * as TestUtils from "./test_utils";
 import { collectEventsNRT } from "./playback_test_utils";
 import * as Playback from "./playback";
 import { Store, makeInitialState } from "./efx";
-import * as TopLevel from "./top_level";
+import * as TopLevel from "gallium/lib/top_level";
 
 function parseAndInterpret(code: string) {
   return TopLevel.interpret(TopLevel.parseAndResolve(code));

--- a/gallium/package.json
+++ b/gallium/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "scripts": {
-    "build": "yarn clean && yarn build-babel && yarn build-flow",
+    "build": "yarn build-babel && yarn build-flow",
     "clean": "rm -rf ./lib",
     "build-babel": "babel src --out-dir lib --ignore '*.test.js'",
     "build-flow": "flow-copy-source --ignore '*.test.js' src lib",

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -3,48 +3,32 @@
 import type { ABT } from "./resolver";
 import * as AST from "./AST";
 
-export class IContext<State> {
-  state: State;
+type IState = {
+  counter: number
+}
 
-  befores: Array<IContext<State> => void> = [];
-  afters: Array<IContext<State> => void> = [];
+export class IContext {
+  state: IState;
 
-  constructor(state: State) {
+  constructor(state: IState) {
     this.state = state;
   }
 
-  before() {
-    for (const before of this.befores) {
-      before(this);
-    }
-  }
-
-  after() {
-    for (const after of this.afters) {
-      after(this);
-    }
-  }
-  /*
-   *   forNextIteration(up: State => State, down: State => State) {
-   *     befores.push(() => {
-   *       up();
-   *       befores.push(() => {
-   *         down();
-   *       });
-   *     });
-   *   }*/
-
-  run<B>(f: IContext<State> => B): B {
+  run<B>(f: IContext => B): B {
     return f(this);
   }
 }
 
-export const interpret = <State>(node: ABT): (IContext<State> => any) => ctx => {
+type Interpreter = ABT => IContext => any;
+
+export const interpret: Interpreter = (node: ABT): (IContext => any) => ctx => {
   if (node instanceof AST.Paren) {
     return ctx.run(interpret(node.children[0]));
   }
 
-  // TODO: interpret literals
+  if (node instanceof AST.NumLit || node instanceof AST.Name) {
+    return node.data.value;
+  }
   if (node instanceof AST.NumLit || node instanceof AST.Name) {
     return node.data.value;
   }

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -6,9 +6,33 @@ import * as AST from "./AST";
 export class IContext<State> {
   state: State;
 
+  befores: Array<IContext<State> => void> = [];
+  afters: Array<IContext<State> => void> = [];
+
   constructor(state: State) {
     this.state = state;
   }
+
+  before() {
+    for (const before of this.befores) {
+      before(this);
+    }
+  }
+
+  after() {
+    for (const after of this.afters) {
+      after(this);
+    }
+  }
+  /*
+   *   forNextIteration(up: State => State, down: State => State) {
+   *     befores.push(() => {
+   *       up();
+   *       befores.push(() => {
+   *         down();
+   *       });
+   *     });
+   *   }*/
 
   run<B>(f: IContext<State> => B): B {
     return f(this);
@@ -20,6 +44,7 @@ export const interpret = <State>(node: ABT): (IContext<State> => any) => ctx => 
     return ctx.run(interpret(node.children[0]));
   }
 
+  // TODO: interpret literals
   if (node instanceof AST.NumLit || node instanceof AST.Name) {
     return node.data.value;
   }

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -3,13 +3,19 @@
 import type { ABT } from "./resolver";
 import * as AST from "./AST";
 
-type IContext<State: {}> = {
+export class IContext<State> {
   state: State
-};
+  constructor(state: State) {
+    this.state = state;
+  }
+  run<B>(f: IContext<State> => B): B {
+    return f(this);
+  }
+}
 
-export const interpret = (node: ABT): any => {
+export const interpret = <State>(node: ABT): (IContext<State> => any) => ctx => {
   if (node instanceof AST.Paren) {
-    return interpret(node.children[0]);
+    return ctx.run(interpret(node.children[0]));
   }
 
   if (node instanceof AST.NumLit || node instanceof AST.Name) {
@@ -17,10 +23,14 @@ export const interpret = (node: ABT): any => {
   }
 
   if (node instanceof AST.HApp || node instanceof AST.VApp) {
-    const f = interpret(node.children[0]);
-    const args = node.children.slice(1).map(interpret);
+    const f = ctx.run(interpret(node.children[0]));
+    let args = [];
+    for (const child of node.children.slice(1)) {
+      const result = ctx.run(interpret(child));
+      args.push(result);
+    }
     return f(args);
   }
 
-  throw new Error("error");
+  throw new Error("Interpreter Error");
 };

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -5,7 +5,7 @@ import * as AST from "./AST";
 
 type IState = {
   +numLitInterpreter: number => any
-}
+};
 
 export class IContext {
   state: IState;
@@ -20,13 +20,13 @@ export class IContext {
 }
 
 const getValue: Interpreter = node => ctx => {
-  if (node.data.hasOwnProperty('value')) {
+  if (node.data.hasOwnProperty("value")) {
     return node.data.value;
   } else if (node.data.impureValue) {
     return ctx.run(node.data.impureValue);
   }
   throw new Error("Unexpected Error");
-}
+};
 
 type Interpreter = ABT => IContext => any;
 

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -51,7 +51,7 @@ export const interpret: Interpreter = (node: ABT): (IContext => any) => ctx => {
       const result = ctx.run(interpret(child));
       args.push(result);
     }
-    const ret = ctx.run(f(args));
+    const ret = f(args);
     ctx.state = savedState;
     return ret;
   }

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -4,10 +4,12 @@ import type { ABT } from "./resolver";
 import * as AST from "./AST";
 
 export class IContext<State> {
-  state: State
+  state: State;
+
   constructor(state: State) {
     this.state = state;
   }
+
   run<B>(f: IContext<State> => B): B {
     return f(this);
   }
@@ -29,7 +31,7 @@ export const interpret = <State>(node: ABT): (IContext<State> => any) => ctx => 
       const result = ctx.run(interpret(child));
       args.push(result);
     }
-    return f(args);
+    return ctx.run(f(args));
   }
 
   throw new Error("Interpreter Error");

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -9,7 +9,7 @@ type State = {
 
 const bindingContext: BindingContext = {
   join: {
-    value: (xs: Array<string>) => (ctx: IContext): string => {
+    value: (xs: Array<string>) => {
       return `(${xs.join(",")})`;
     }
   },

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -3,44 +3,85 @@ import { parse } from "./parser";
 import { resolve, type BindingContext } from "./resolver";
 import { interpret, IContext } from "./interpreter";
 
-describe("interpretation", () => {
-  const bindingContext: BindingContext = {
-    foo: {
-      value: (x: Array<number>) => {
-        return `fooTransformer ${JSON.stringify(x)}`;
-      }
-    },
-    bar: {
-      value: 100
-    }
-  };
+type State = {
+  counter: number
+};
 
-  const interpreterContext = new IContext({});
+const bindingContext: BindingContext = {
+  pureFunction: {
+    value: (x: Array<number>) => (ctx: IContext<State>): string => {
+      return `pureFunction ${JSON.stringify(x)}`;
+    }
+  },
+  statefulFunction: {
+    value: (x: Array<number>) => (ctx: IContext<State>): string => {
+      ctx.state.counter += 1;
+      return `statefulFunction ${JSON.stringify(x)}`;
+    }
+  },
+  bar: {
+    value: 100
+  }
+};
+
+const makeInterpreterContext = (): IContext<State> => {
+  return new IContext({
+    counter: 0
+  });
+};
+
+describe("interpretation", () => {
 
   it("should be able to interpret 0's", () => {
     const ast = parse("0");
     const abt = resolve(bindingContext, ast);
-    expect(interpreterContext.run(interpret(abt))).toBe(0);
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe(0);
   });
 
   it("should be able to interpret decimals", () => {
     const ast = parse("0.5");
     const abt = resolve(bindingContext, ast);
-    expect(interpreterContext.run(interpret(abt))).toBe(0.5);
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe(0.5);
   });
 
   it("should be able to interpret horizontal application", () => {
-    const ast = parse("(foo bar 2 3)");
+    const ast = parse("(pureFunction bar 2 3)");
     const abt = resolve(bindingContext, ast);
-    expect(interpreterContext.run(interpret(abt))).toBe("fooTransformer [100,2,3]");
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe("pureFunction [100,2,3]");
   });
 
   it("should be able to interpret vertical application", () => {
-    const ast = parse(`foo
+    const ast = parse(`pureFunction
   bar
   2
   3`);
     const abt = resolve(bindingContext, ast);
-    expect(interpreterContext.run(interpret(abt))).toBe("fooTransformer [100,2,3]");
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe("pureFunction [100,2,3]");
+  });
+
+  it("should be able to execute stateful computations", () => {
+    const ast = parse(`statefulFunction
+  bar
+  2
+  3`);
+    const abt = resolve(bindingContext, ast);
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe("statefulFunction [100,2,3]");
+    expect(ctx.state.counter).toBe(1);
+  });
+
+  it("should be able to execute single-level stateful computations", () => {
+    const ast = parse(`statefulFunction
+  bar
+  2
+  3`);
+    const abt = resolve(bindingContext, ast);
+    const ctx = makeInterpreterContext();
+    expect(ctx.run(interpret(abt))).toBe("statefulFunction [100,2,3]");
+    expect(ctx.state.counter).toBe(1);
   });
 });

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -1,7 +1,7 @@
 // @flow
 import { parse } from "./parser";
 import { resolve, type BindingContext } from "./resolver";
-import { interpret } from "./interpreter";
+import { interpret, IContext } from "./interpreter";
 
 describe("interpretation", () => {
   const bindingContext: BindingContext = {
@@ -15,22 +15,24 @@ describe("interpretation", () => {
     }
   };
 
+  const interpreterContext = new IContext({});
+
   it("should be able to interpret 0's", () => {
     const ast = parse("0");
     const abt = resolve(bindingContext, ast);
-    expect(interpret(abt)).toBe(0);
+    expect(interpreterContext.run(interpret(abt))).toBe(0);
   });
 
   it("should be able to interpret decimals", () => {
     const ast = parse("0.5");
     const abt = resolve(bindingContext, ast);
-    expect(interpret(abt)).toBe(0.5);
+    expect(interpreterContext.run(interpret(abt))).toBe(0.5);
   });
 
   it("should be able to interpret horizontal application", () => {
     const ast = parse("(foo bar 2 3)");
     const abt = resolve(bindingContext, ast);
-    expect(interpret(abt)).toBe("fooTransformer [100,2,3]");
+    expect(interpreterContext.run(interpret(abt))).toBe("fooTransformer [100,2,3]");
   });
 
   it("should be able to interpret vertical application", () => {
@@ -39,6 +41,6 @@ describe("interpretation", () => {
   2
   3`);
     const abt = resolve(bindingContext, ast);
-    expect(interpret(abt)).toBe("fooTransformer [100,2,3]");
+    expect(interpreterContext.run(interpret(abt))).toBe("fooTransformer [100,2,3]");
   });
 });

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -9,12 +9,12 @@ type State = {
 
 const bindingContext: BindingContext = {
   pureFunction: {
-    value: (x: Array<number>) => (ctx: IContext<State>): string => {
+    value: (x: Array<number>) => (ctx: IContext): string => {
       return `pureFunction ${JSON.stringify(x)}`;
     }
   },
   statefulFunction: {
-    value: (x: Array<number>) => (ctx: IContext<State>): string => {
+    value: (x: Array<number>) => (ctx: IContext): string => {
       ctx.state.counter += 1;
       return `statefulFunction ${JSON.stringify(x)}`;
     }
@@ -24,7 +24,7 @@ const bindingContext: BindingContext = {
   }
 };
 
-const makeInterpreterContext = (): IContext<State> => {
+const makeInterpreterContext = (): IContext => {
   return new IContext({
     counter: 0
   });

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -3,7 +3,7 @@ import * as AST from "./AST";
 import { type Transformer } from "./semantics";
 import { IContext } from "./interpreter";
 
-type Term = { value?: any, impureValue?: IContext => any };
+export type Term = { value?: any, impureValue?: IContext => any };
 
 export type ABT = AST.With<Term>;
 

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -2,8 +2,13 @@
 import * as AST from "./AST";
 import { type Transformer } from "./semantics";
 import { IContext } from "./interpreter";
+import * as Types from "./types";
 
-export type Term = { value?: any, impureValue?: IContext => any };
+export type Term = {
+  type?: Types.Type,
+  value?: any,
+  impureValue?: IContext => any
+};
 
 export type ABT = AST.With<Term>;
 

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -3,7 +3,7 @@ import * as AST from "./AST";
 import { type Transformer } from "./semantics";
 import { IContext } from "./interpreter";
 
-type Term = { value?: any, impureValue?: IContext => any};
+type Term = { value?: any, impureValue?: IContext => any };
 
 export type ABT = AST.With<Term>;
 

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -1,8 +1,9 @@
 // @flow
 import * as AST from "./AST";
 import { type Transformer } from "./semantics";
+import { IContext } from "./interpreter";
 
-type Term = { value?: any };
+type Term = { value?: any, impureValue?: IContext => any};
 
 export type ABT = AST.With<Term>;
 
@@ -16,7 +17,7 @@ export const resolve = (context: BindingContext, node: AST.Base): ABT => {
 
 const resolveStep = (context: BindingContext) => (
   node: AST.Base
-): AST.PartiallyWith<{ value?: any }, AST.Base> => {
+): AST.PartiallyWith<Term, AST.Base> => {
   if (node instanceof AST.Name) {
     if (!(node.value in context)) {
       throw new Error(`Could not resolve variable ${node.value}`);

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -1,0 +1,22 @@
+// @flow
+import * as TopLevel from "./top_level";
+import { type Pattern } from "./semantics";
+
+const parse = (code: string): Pattern<Uint8Array> => {
+  return TopLevel.interpret(TopLevel.parseAndResolve(code));
+};
+
+it("allows arguments", () => {
+  const pattern = parse(`note 60 72`);
+  expect(pattern(0, 1)).toEqual([
+    { start: 0, end: 1, value: new Uint8Array([144, 60, 127]) }
+  ]);
+  expect(pattern(1, 2)).toEqual([
+    { start: 1, end: 2, value: new Uint8Array([144, 72, 127]) }
+  ]);
+});
+
+it("throws a type error when given a list processor with no arguments", () => {
+  const parsePattern = () => parse(`note`);
+  expect(parsePattern).toThrow();
+});

--- a/gallium/src/type_checker.js
+++ b/gallium/src/type_checker.js
@@ -1,0 +1,33 @@
+// @flow
+
+import * as AST from "./AST";
+import { type ABT } from "./resolver";
+import * as Types from "./types";
+
+type Context = {
+  type: Types.Type
+};
+
+export const check = (node: ABT, ctx: Context): void => {
+  if (node instanceof AST.HApp || node instanceof AST.VApp) {
+    const funType = node.children[0].data.type;
+    if (funType.tag === "listProcessor") {
+      const outputType = funType.output;
+      const inputType = funType.input;
+
+      if (outputType !== ctx.type) {
+        throw new Error("type error");
+      }
+
+      for (const input of node.children.slice(1)) {
+        check(input, { type: inputType });
+      }
+    }
+  }
+
+  if (node instanceof AST.Name) {
+    if (node.data.type !== ctx.type) {
+      throw new Error("type error");
+    }
+  }
+};

--- a/gallium/src/types.js
+++ b/gallium/src/types.js
@@ -1,0 +1,31 @@
+// @flow
+
+export const transformer: Type = "transformer";
+
+export const number: Type = "number";
+export const string: Type = "string";
+
+export const listProcessor: Type = (input: Type, output: Type): Type => {
+  return {
+    tag: "listProcessor",
+    input,
+    output
+  };
+};
+
+export const func: Type = (input: Type, output: Type): Type => {
+  return {
+    tag: "func",
+    input,
+    output
+  };
+};
+
+export const list: Type = (value: Type): Type => {
+  return {
+    tag: "list",
+    value
+  };
+};
+
+export type Type = any;


### PR DESCRIPTION
# Context-dependent literal interpretation
This PR introduces impure values that can modify the interpreter state. We use this to implement context-dependent literal interpretation.

---

Now

```
note 1 2 3
```
evaluates during interpretation of the gallium term to the same JS term as:

```
alt (note 1) (note 2) (note 3)
```

In other words, numeric literals now can be interpreted arbitrarily depending on the context.

This allows for a more concise syntax for livecoding by allowing other transformers in variadic function applications:

```
note 1 2 (do (fast 2) (note 3))
```

```
add 12 (fast 2)
```
We can probably use this scoped state later to implement
- MIDI channel switching/ MIDI output switching
- lexical scoping for lets and lambdas.

Closes #74 

# Type-checking

This PR also includes a rudimentary type-checker that does enough to prevent runtime errors when querying patterns. No more abrupt pauses when typing out expressions!

Closes #49 
---
TODO:
- [x] move top level to gallium
- [x] implement type checker