### PR TITLE
Impure functions + MIDI Channel selection

### DIFF
--- a/gallium-live/src/playback_test_utils.js
+++ b/gallium-live/src/playback_test_utils.js
@@ -2,11 +2,12 @@
 import * as TestUtils from "./test_utils";
 import * as Playback from "./playback";
 import { type Pattern, silence } from "gallium/lib/semantics";
+import { type Parameters } from "gallium/lib/top_level";
 import { type Action } from "./efx";
 
 export const collectEventsNRT: Action<
   {
-    pattern: Pattern<Uint8Array>,
+    pattern: Pattern<Parameters>,
     numBeats: number
   },
   Promise<Array<any>>

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -45,7 +45,6 @@ export const interpret: Interpreter = (node: ABT): (IContext => any) => ctx => {
   }
 
   if (node instanceof AST.HApp || node instanceof AST.VApp) {
-    const savedState = ctx.state;
     const f = ctx.run(interpret(node.children[0]));
     let args = [];
     for (const child of node.children.slice(1)) {

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -51,8 +51,7 @@ export const interpret: Interpreter = (node: ABT): (IContext => any) => ctx => {
       const result = ctx.run(interpret(child));
       args.push(result);
     }
-    const ret = f(args);
-    ctx.state = savedState;
+    const ret = ctx.run(f(args));
     return ret;
   }
 

--- a/gallium/src/interpreter.js
+++ b/gallium/src/interpreter.js
@@ -4,7 +4,8 @@ import type { ABT } from "./resolver";
 import * as AST from "./AST";
 
 type IState = {
-  +numLitInterpreter: number => any
+  +numLitInterpreter: number => IContext => any,
+  +channel: number
 };
 
 export class IContext {
@@ -36,7 +37,7 @@ export const interpret: Interpreter = (node: ABT): (IContext => any) => ctx => {
   }
 
   if (node instanceof AST.NumLit) {
-    return ctx.state.numLitInterpreter(node.data.value);
+    return ctx.run(ctx.state.numLitInterpreter(node.data.value));
   }
 
   if (node instanceof AST.Name) {

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -1,6 +1,6 @@
 // @flow
 import { parse } from "./parser";
-import { resolve, type BindingContext } from "./resolver";
+import { pure, resolve, type BindingContext } from "./resolver";
 import { interpret, IContext } from "./interpreter";
 
 type State = {
@@ -10,25 +10,39 @@ type State = {
 const bindingContext: BindingContext = {
   join: {
     value: (xs: Array<string>) => {
-      return `(${xs.join(",")})`;
+      return pure(`(${xs.join(",")})`);
     }
   },
-  joinWithDoubledNumbers: {
+  lexicalJoinWithDoubledNumbers: {
     impureValue: (ctx: IContext) => {
+      const oldState = ctx.state;
       ctx.state = {
         ...ctx.state,
         numLitInterpreter: x => `${x * 2}`
       };
-      return bindingContext.join.value;
+      return xs => ctx => {
+        ctx.state = {
+          ...ctx.state,
+          numLitInterpreter: oldState.numLitInterpreter
+        };
+        return `(${xs.join(",")})`;
+      }
     }
   },
-  joinWithTripledNumbers: {
+  lexicalJoinWithTripledNumbers: {
     impureValue: (ctx: IContext) => {
+      const oldState = ctx.state;
       ctx.state = {
         ...ctx.state,
         numLitInterpreter: x => `${x * 3}`
       };
-      return bindingContext.join.value;
+      return xs => ctx => {
+        ctx.state = {
+          ...ctx.state,
+          numLitInterpreter: oldState.numLitInterpreter
+        };
+        return `(${xs.join(",")})`;
+      }
     }
   },
   asdf: {
@@ -82,9 +96,9 @@ describe("interpretation", () => {
   });
 });
 
-describe("scoped impure computations", () => {
-  test("top-level scoped impure computations", () => {
-    const ast = parse(`joinWithDoubledNumbers
+describe("lexical impure computations", () => {
+  test("top-level lexical impure computations", () => {
+    const ast = parse(`lexicalJoinWithDoubledNumbers
   1
   2
   3`);
@@ -93,28 +107,28 @@ describe("scoped impure computations", () => {
     expect(ctx.run(interpret(abt))).toBe(`(2,4,6)`);
   });
 
-  test("scoped impure computations should not leak", () => {
+  test("lexical impure computations should not leak", () => {
     const ast = parse(`join
   1
-  joinWithDoubledNumbers 1
+  lexicalJoinWithDoubledNumbers 1
   1`);
     const abt = resolve(bindingContext, ast);
     const ctx = makeInterpreterContext();
     expect(ctx.run(interpret(abt))).toBe(`(1,(2),1)`);
   });
 
-  test("scoped impure computations can be nested", () => {
-    const ast = parse(`joinWithDoubledNumbers
+  test("lexical impure computations can be nested", () => {
+    const ast = parse(`lexicalJoinWithDoubledNumbers
   1
-  joinWithTripledNumbers 1
+  lexicalJoinWithTripledNumbers 1
   1`);
     const abt = resolve(bindingContext, ast);
     const ctx = makeInterpreterContext();
     expect(ctx.run(interpret(abt))).toBe(`(2,(3),2)`);
   });
 
-  test("scoped impure computations should persist throughout scope", () => {
-    const ast = parse(`joinWithDoubledNumbers
+  test("lexical impure computations should persist throughout scope", () => {
+    const ast = parse(`lexicalJoinWithDoubledNumbers
   1
   join 1
   1`);

--- a/gallium/src/interpreter.test.js
+++ b/gallium/src/interpreter.test.js
@@ -3,10 +3,6 @@ import { parse } from "./parser";
 import { pure, resolve, type BindingContext } from "./resolver";
 import { interpret, IContext } from "./interpreter";
 
-type State = {
-  literalIntepretation: number => any
-};
-
 const bindingContext: BindingContext = {
   join: {
     value: (xs: Array<string>) => {
@@ -18,7 +14,7 @@ const bindingContext: BindingContext = {
       const oldState = ctx.state;
       ctx.state = {
         ...ctx.state,
-        numLitInterpreter: x => `${x * 2}`
+        numLitInterpreter: x => ctx => `${x * 2}`
       };
       return xs => ctx => {
         ctx.state = {
@@ -26,7 +22,7 @@ const bindingContext: BindingContext = {
           numLitInterpreter: oldState.numLitInterpreter
         };
         return `(${xs.join(",")})`;
-      }
+      };
     }
   },
   lexicalJoinWithTripledNumbers: {
@@ -34,7 +30,7 @@ const bindingContext: BindingContext = {
       const oldState = ctx.state;
       ctx.state = {
         ...ctx.state,
-        numLitInterpreter: x => `${x * 3}`
+        numLitInterpreter: x => ctx => `${x * 3}`
       };
       return xs => ctx => {
         ctx.state = {
@@ -42,7 +38,7 @@ const bindingContext: BindingContext = {
           numLitInterpreter: oldState.numLitInterpreter
         };
         return `(${xs.join(",")})`;
-      }
+      };
     }
   },
   asdf: {
@@ -52,7 +48,8 @@ const bindingContext: BindingContext = {
 
 const makeInterpreterContext = (): IContext => {
   return new IContext({
-    numLitInterpreter: x => `${x}`
+    numLitInterpreter: x => ctx => `${x}`,
+    channel: 0
   });
 };
 

--- a/gallium/src/midi_utils.js
+++ b/gallium/src/midi_utils.js
@@ -1,0 +1,17 @@
+// @flow
+
+type MIDINote = {
+  channel: number,
+  pitch: number,
+  velocity: number
+};
+
+export const noteOn = (data: MIDINote) => {
+  const { channel, pitch, velocity } = data;
+  return new Uint8Array([9 * 16 + channel, pitch, velocity]);
+};
+
+export const noteOff = (data: MIDINote) => {
+  const { channel, pitch, velocity } = data;
+  return new Uint8Array([8 * 16 + channel, pitch, velocity]);
+};

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -17,9 +17,8 @@ export const pureFn = <A, B>(f: A => B): (A => Impure<B>) => {
 export type Term<A> = {
   type?: Types.Type,
   value?: A,
-  impureValue?: Impure<A>,
+  impureValue?: Impure<A>
 };
-
 
 export type ABT = AST.With<Term<any>>;
 

--- a/gallium/src/resolver.js
+++ b/gallium/src/resolver.js
@@ -4,17 +4,28 @@ import { type Transformer } from "./semantics";
 import { IContext } from "./interpreter";
 import * as Types from "./types";
 
-export type Term = {
-  type?: Types.Type,
-  value?: any,
-  impureValue?: IContext => any
+export type Impure<A> = IContext => A;
+
+export const pure = <A>(x: A): Impure<A> => {
+  return () => x;
 };
 
-export type ABT = AST.With<Term>;
+export const pureFn = <A, B>(f: A => B): (A => Impure<B>) => {
+  return x => pure(f(x));
+};
 
-export type BindingContext = { [string]: Term };
+export type Term<A> = {
+  type?: Types.Type,
+  value?: A,
+  impureValue?: Impure<A>,
+};
 
-type Step = AST.Base => AST.PartiallyWith<Term, AST.Base>;
+
+export type ABT = AST.With<Term<any>>;
+
+export type BindingContext = { [string]: Term<any> };
+
+type Step = AST.Base => AST.PartiallyWith<Term<any>, AST.Base>;
 
 export const resolve = (context: BindingContext, node: AST.Base): ABT => {
   return AST.traverse(resolveStep(context))(node);
@@ -22,7 +33,7 @@ export const resolve = (context: BindingContext, node: AST.Base): ABT => {
 
 const resolveStep = (context: BindingContext) => (
   node: AST.Base
-): AST.PartiallyWith<Term, AST.Base> => {
+): AST.PartiallyWith<Term<*>, AST.Base> => {
   if (node instanceof AST.Name) {
     if (!(node.value in context)) {
       throw new Error(`Could not resolve variable ${node.value}`);

--- a/gallium/src/top_level.js
+++ b/gallium/src/top_level.js
@@ -44,11 +44,11 @@ function altWithNumLitInterpreter<A>(
   return {
     type: Types.listProcessor(Types.transformer, Types.transformer),
     impureValue: (ctx: IContext) => {
-      const { numLitInterpreter: oldNumLitInterpreter } = ctx.state;
+      const oldState = ctx.state;
       ctx.state = { ...ctx.state, numLitInterpreter };
       return transformers => ctx => {
         const ret = alt(transformers);
-        ctx.state = { ...ctx.state, numLitInterpreter: oldNumLitInterpreter };
+        ctx.state = oldState;
         return ret;
       };
     }
@@ -127,13 +127,13 @@ const globalContext: BindingContext = {
   channel: {
     type: Types.func(Types.number, Types.transformer),
     impureValue: ctx => {
-      const state0 = ctx.state;
+      const oldState = ctx.state;
       ctx.state = { ...ctx.state, numLitInterpreter: x => () => x };
       return ([channel]) => ctx => {
         ctx.state = {
           ...ctx.state,
           channel: channel,
-          numLitInterpreter: state0.numLitInterpreter
+          numLitInterpreter: oldState.numLitInterpreter
         };
         return x => x;
       };

--- a/gallium/src/top_level.js
+++ b/gallium/src/top_level.js
@@ -109,7 +109,13 @@ const globalContext: BindingContext = {
   fast: altWithPureNumLitInterpreter(x => fast(Math.min(x, 128))),
   add: altWithPureNumLitInterpreter(x => pitchMap(p => p + x)),
   sub: altWithPureNumLitInterpreter(x => pitchMap(p => p - x)),
-  shift: altWithPureNumLitInterpreter(shift)
+  shift: altWithPureNumLitInterpreter(shift),
+  channel: altWithNumLitInterpreter(channel => ctx => {
+    ctx.state = {
+      ...ctx.state,
+      channel
+    };
+  })
 };
 
 const makeDefaultInterpreterContext = () =>

--- a/gallium/src/top_level.js
+++ b/gallium/src/top_level.js
@@ -82,11 +82,11 @@ const note = (pitch: number): Impure<Transformer<Parameters>> => {
 const globalContext: BindingContext = {
   i: {
     type: Types.transformer,
-    value: pureFn(x => x)
+    value: x => x
   },
   m: {
     type: Types.transformer,
-    value: pureFn(() => silence)
+    value: () => silence
   },
   do: {
     type: Types.listProcessor(Types.transformer, Types.transformer),

--- a/gallium/src/top_level.js
+++ b/gallium/src/top_level.js
@@ -55,12 +55,6 @@ function altWithNumLitInterpreter<A>(
   };
 }
 
-function altWithPureNumLitInterpreter<A>(
-  pureNumLitInterpreter: number => A
-): Term<(Array<Transformer<A>>) => Impure<Transformer<A>>> {
-  return altWithNumLitInterpreter(pureFn(pureNumLitInterpreter));
-}
-
 export type Parameters = {
   channel: number,
   pitch: number
@@ -119,11 +113,11 @@ const globalContext: BindingContext = {
     impureValue: backtrackPureFn(alt)
   },
   note: altWithNumLitInterpreter(note),
-  slow: altWithPureNumLitInterpreter(x => slow(Math.max(x, 1 / 128))),
-  fast: altWithPureNumLitInterpreter(x => fast(Math.min(x, 128))),
-  add: altWithPureNumLitInterpreter(x => pitchMap(p => p + x)),
-  sub: altWithPureNumLitInterpreter(x => pitchMap(p => p - x)),
-  shift: altWithPureNumLitInterpreter(shift),
+  slow: altWithNumLitInterpreter(pureFn(x => slow(Math.max(x, 1 / 128)))),
+  fast: altWithNumLitInterpreter(pureFn(x => fast(Math.min(x, 128)))),
+  add: altWithNumLitInterpreter(pureFn(x => pitchMap(p => p + x))),
+  sub: altWithNumLitInterpreter(pureFn(x => pitchMap(p => p - x))),
+  shift: altWithNumLitInterpreter(pureFn(shift)),
   channel: {
     type: Types.func(Types.number, Types.transformer),
     impureValue: ctx => {

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -27,18 +27,24 @@ it("throws a type error when given an invalid parenthesized argument", () => {
   expect(parsePattern).toThrow();
 });
 
-it("allows changes in channel", () => {
-  const pattern = parse(`do (channel 1) (note 0)`);
-  expect(pattern(0, 1)).toEqual([
-    { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
-  ]);
-});
+describe("channel", () => {
+  test("setting", () => {
+    const pattern = parse(`do (channel 1) (note 0)`);
+    expect(pattern(0, 1)).toEqual([
+      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+    ]);
+  });
 
-it("TODO: rename test", () => {
-  const pattern = parse(`do (channel 1) (note 0) (channel 1)`);
-  expect(pattern(0, 1)).toEqual([
-    { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
-  ]);
+  test("having multiple values type-errors", () => {
+    expect(() => parse(`do (channel 0 1) (note 0)`)).toThrow();
+  });
+
+  test("extraneous changes result in no-op", () => {
+    const pattern = parse(`do (channel 1) (note 0) (channel 1)`);
+    expect(pattern(0, 1)).toEqual([
+      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+    ]);
+  });
 });
 
 test("i is a no-op", () => {

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -1,6 +1,7 @@
 // @flow
 import * as TopLevel from "./top_level";
 import { type Pattern } from "./semantics";
+import * as MIDIUtils from "./midi_utils";
 
 const parse = (code: string): Pattern<Uint8Array> => {
   return TopLevel.interpret(TopLevel.parseAndResolve(code));
@@ -9,10 +10,18 @@ const parse = (code: string): Pattern<Uint8Array> => {
 it("allows arguments", () => {
   const pattern = parse(`note 60 72`);
   expect(pattern(0, 1)).toEqual([
-    { start: 0, end: 1, value: new Uint8Array([144, 60, 127]) }
+    {
+      start: 0,
+      end: 1,
+      value: MIDIUtils.noteOn({ channel: 0, pitch: 60, velocity: 127 })
+    }
   ]);
   expect(pattern(1, 2)).toEqual([
-    { start: 1, end: 2, value: new Uint8Array([144, 72, 127]) }
+    {
+      start: 1,
+      end: 2,
+      value: MIDIUtils.noteOn({ channel: 0, pitch: 72, velocity: 127 })
+    }
   ]);
 });
 
@@ -24,4 +33,15 @@ it("throws a type error when given a list processor with no arguments", () => {
 it("throws a type error when given an invalid parenthesized argument", () => {
   const parsePattern = () => parse(`do (shift) 0.5`);
   expect(parsePattern).toThrow();
+});
+
+it("allows changes in channel", () => {
+  const pattern = parse(`do (channel 1) (note 0)`);
+  expect(pattern(0, 1)).toEqual([
+    {
+      start: 0,
+      end: 1,
+      value: MIDIUtils.noteOn({ channel: 1, pitch: 0, velocity: 127 })
+    }
+  ]);
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as TopLevel from "./top_level";
-import { type Pattern } from "./semantics";
+import { silence, type Pattern } from "./semantics";
 import * as MIDIUtils from "./midi_utils";
 
 const parse = (code: string): Pattern<TopLevel.Parameters> => {
@@ -32,4 +32,12 @@ it("allows changes in channel", () => {
   expect(pattern(0, 1)).toEqual([
     { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
   ]);
+});
+
+test("i is a no-op", () => {
+  expect(parse(`do (note 0) i`)(0, 1)).toEqual(parse(`do (note 0)`)(0, 1));
+});
+
+test("m mutes", () => {
+  expect(parse(`do (note 0) m`)(0, 1)).toEqual([]);
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -34,6 +34,13 @@ it("allows changes in channel", () => {
   ]);
 });
 
+it("TODO: rename test", () => {
+  const pattern = parse(`do (channel 1) (note 0) (channel 1)`);
+  expect(pattern(0, 1)).toEqual([
+    { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+  ]);
+});
+
 test("i is a no-op", () => {
   expect(parse(`do (note 0) i`)(0, 1)).toEqual(parse(`do (note 0)`)(0, 1));
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -3,25 +3,17 @@ import * as TopLevel from "./top_level";
 import { type Pattern } from "./semantics";
 import * as MIDIUtils from "./midi_utils";
 
-const parse = (code: string): Pattern<Uint8Array> => {
+const parse = (code: string): Pattern<TopLevel.Parameters> => {
   return TopLevel.interpret(TopLevel.parseAndResolve(code));
 };
 
 it("allows arguments", () => {
   const pattern = parse(`note 60 72`);
   expect(pattern(0, 1)).toEqual([
-    {
-      start: 0,
-      end: 1,
-      value: MIDIUtils.noteOn({ channel: 0, pitch: 60, velocity: 127 })
-    }
+    { start: 0, end: 1, value: { channel: 0, pitch: 60 } }
   ]);
   expect(pattern(1, 2)).toEqual([
-    {
-      start: 1,
-      end: 2,
-      value: MIDIUtils.noteOn({ channel: 0, pitch: 72, velocity: 127 })
-    }
+    { start: 1, end: 2, value: { channel: 0, pitch: 72 } }
   ]);
 });
 
@@ -38,10 +30,6 @@ it("throws a type error when given an invalid parenthesized argument", () => {
 it("allows changes in channel", () => {
   const pattern = parse(`do (channel 1) (note 0)`);
   expect(pattern(0, 1)).toEqual([
-    {
-      start: 0,
-      end: 1,
-      value: MIDIUtils.noteOn({ channel: 1, pitch: 0, velocity: 127 })
-    }
+    { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
   ]);
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -45,6 +45,26 @@ describe("channel", () => {
       { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
     ]);
   });
+
+  test("is block-scoped", () => {
+    const pattern = parse(`alt (do (channel 1) (note 0)) (note 0)`);
+    expect(pattern(0, 1)).toEqual([
+      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+    ]);
+    expect(pattern(1, 2)).toEqual([
+      { start: 1, end: 2, value: { channel: 0, pitch: 0 } }
+    ]);
+  });
+
+  test("is block-scoped (2)", () => {
+    const pattern = parse(`alt (do (channel 1) (do (channel 2) 0)) (note 0)`);
+    expect(pattern(1, 2)).toEqual([
+      { start: 1, end: 2, value: { channel: 0, pitch: 0 } }
+    ]);
+    expect(pattern(0, 1)).toEqual([
+      { start: 0, end: 1, value: { channel: 2, pitch: 0 } }
+    ]);
+  });
 });
 
 test("i is a no-op", () => {

--- a/gallium/src/type_checker.js
+++ b/gallium/src/type_checker.js
@@ -22,6 +22,19 @@ export const check = (node: ABT, ctx: Context): void => {
       for (const input of node.children.slice(1)) {
         check(input, { type: inputType });
       }
+    } else if (funType.tag == "func") {
+      const outputType = funType.output;
+      const inputType = funType.input;
+
+      if (outputType !== ctx.type) {
+        throw new Error("type error");
+      }
+
+      if (node.children.length > 2) {
+        throw new Error("too many arguments: expected just one");
+      }
+
+      check(node.children[1], { type: inputType });
     }
   }
 


### PR DESCRIPTION
- backtracking interpreter state for lexical-scoped effects is no longer manually done in the interpreter, but in the term definition
- all functions are treated now as impure; they are lifted from JS with `pureFn`
- MIDI Channel selection implemented as an impure function, `channel`

Closes #45 

TODO:
- [x] make block scoped
- [x] fix failing test
- [x] make all state backtracked