### PR TITLE
zoomed alternation helpers + len

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Sets the MIDI channel.
 (len): Number -> P
 ````
 
-Changes then note length
+Sets the note lengths in beats. Default length is 1.
 
 *Alternates between pipes on every beat.*
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,36 @@ alt : ...P -> P
 
 Alternates between pipes on every beat.
 
+### alt0, alt1, alt2, alt3, alt4, alt5, alt6
+
+```
+alt(n) : ...P -> P
+```
+
+Alternates between pipes every 2^n beats.
+
+Note alt0 is equivalent to alt.
+
+### out0, out1, out2, out3, out4, out5, out6
+
+```
+out(n) : ...P -> P
+```
+
+Alternates between pipes every 2^n beats. Pipes perceive time 2^n times slower.
+
+Note out0 is equivalent to alt.
+
+### in0, in1, in2, in3, in4, in5, in6
+
+```
+in(n) : ...P -> P
+```
+
+Alternates between pipes every (1/2)^n beats. Pipes perceive time 2^n times faster.
+
+Note in0 is equivalent to alt.
+
 
 ### MIDI Operators
 
@@ -295,9 +325,9 @@ Alternates between pipes on every beat.
 (note): Number -> P
 ````
 
-*Alternates between pipes on every beat.*
-
 Starts a new stream of MIDI notes. `note` will ignore data from the previous pipe and overwrite it with a new stream.
+
+*Alternates between pipes on every beat.*
 
 #### add
 ```
@@ -305,9 +335,9 @@ Starts a new stream of MIDI notes. `note` will ignore data from the previous pip
 (add): Number -> P
 ````
 
-*Alternates between pipes on every beat.*
-
 Transposes a stream of MIDI notes up a given number of semitones.
+
+*Alternates between pipes on every beat.*
 
 #### sub
 ```
@@ -315,9 +345,9 @@ Transposes a stream of MIDI notes up a given number of semitones.
 (sub): Number -> P
 ````
 
-*Alternates between pipes on every beat.*
-
 Transposes a stream of MIDI notes down a given number of semitones.
+
+*Alternates between pipes on every beat.*
 
 
 #### chan
@@ -327,9 +357,21 @@ Transposes a stream of MIDI notes down a given number of semitones.
 (chan): Number -> P
 ````
 
+Sets the MIDI channel.
+
 *Alternates between pipes on every beat.*
 
-Sets the MIDI channel.
+
+#### len
+
+```
+ len : ...P -> P
+(len): Number -> P
+````
+
+Changes then note length
+
+*Alternates between pipes on every beat.*
 
 
 ### Time Operators

--- a/gallium-live/src/playback.js
+++ b/gallium-live/src/playback.js
@@ -21,8 +21,9 @@ export class Player {
     const now = performance.now();
     const timestampOn =
       now + (event.start - this.state.beat) * getBeatLength(this.state.bpm);
+    const correctedEnd = (event.end - event.start) * event.value.length + event.start;
     const timestampOff =
-      now + (event.end - this.state.beat) * getBeatLength(this.state.bpm) - 1;
+      now + (correctedEnd - this.state.beat) * getBeatLength(this.state.bpm) - 1;
 
     this.state.output.send(
       MIDIUtils.noteOn({

--- a/gallium-live/src/playback.js
+++ b/gallium-live/src/playback.js
@@ -21,9 +21,12 @@ export class Player {
     const now = performance.now();
     const timestampOn =
       now + (event.start - this.state.beat) * getBeatLength(this.state.bpm);
-    const correctedEnd = (event.end - event.start) * event.value.length + event.start;
+    const correctedEnd =
+      (event.end - event.start) * event.value.length + event.start;
     const timestampOff =
-      now + (correctedEnd - this.state.beat) * getBeatLength(this.state.bpm) - 1;
+      now +
+      (correctedEnd - this.state.beat) * getBeatLength(this.state.bpm) -
+      1;
 
     this.state.output.send(
       MIDIUtils.noteOn({

--- a/gallium/src/parser.js
+++ b/gallium/src/parser.js
@@ -23,7 +23,7 @@ export { ParseContext } from "./parser_combinators.js";
 
 export const parseName: Parser<AST.Base> = ctx => {
   const text = ctx.getText();
-  const match = text.match(/^[a-zA-Z]+/);
+  const match = text.match(/^[a-zA-Z][a-zA-Z0-9]*/);
   if (!match) {
     throw new ParseError("not a name");
   }

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -10,10 +10,10 @@ const parse = (code: string): Pattern<TopLevel.Parameters> => {
 it("allows arguments", () => {
   const pattern = parse(`note 60 72`);
   expect(pattern(0, 1)).toEqual([
-    { start: 0, end: 1, value: { channel: 0, pitch: 60 } }
+    { start: 0, end: 1, value: { channel: 0, pitch: 60, length: 1 } }
   ]);
   expect(pattern(1, 2)).toEqual([
-    { start: 1, end: 2, value: { channel: 0, pitch: 72 } }
+    { start: 1, end: 2, value: { channel: 0, pitch: 72, length: 1 } }
   ]);
 });
 
@@ -31,7 +31,7 @@ describe("channel", () => {
   test("setting", () => {
     const pattern = parse(`do (channel 1) (note 0)`);
     expect(pattern(0, 1)).toEqual([
-      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+      { start: 0, end: 1, value: { channel: 1, pitch: 0, length: 1 } }
     ]);
   });
 
@@ -42,27 +42,27 @@ describe("channel", () => {
   test("extraneous changes result in no-op", () => {
     const pattern = parse(`do (channel 1) (note 0) (channel 1)`);
     expect(pattern(0, 1)).toEqual([
-      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+      { start: 0, end: 1, value: { channel: 1, pitch: 0, length: 1 } }
     ]);
   });
 
   test("is block-scoped", () => {
     const pattern = parse(`alt (do (channel 1) (note 0)) (note 0)`);
     expect(pattern(0, 1)).toEqual([
-      { start: 0, end: 1, value: { channel: 1, pitch: 0 } }
+      { start: 0, end: 1, value: { channel: 1, pitch: 0, length: 1 } }
     ]);
     expect(pattern(1, 2)).toEqual([
-      { start: 1, end: 2, value: { channel: 0, pitch: 0 } }
+      { start: 1, end: 2, value: { channel: 0, pitch: 0, length: 1 } }
     ]);
   });
 
   test("is block-scoped (2)", () => {
     const pattern = parse(`alt (do (channel 1) (do (channel 2) 0)) (note 0)`);
     expect(pattern(1, 2)).toEqual([
-      { start: 1, end: 2, value: { channel: 0, pitch: 0 } }
+      { start: 1, end: 2, value: { channel: 0, pitch: 0, length: 1 } }
     ]);
     expect(pattern(0, 1)).toEqual([
-      { start: 0, end: 1, value: { channel: 2, pitch: 0 } }
+      { start: 0, end: 1, value: { channel: 2, pitch: 0, length: 1 } }
     ]);
   });
 });
@@ -91,4 +91,10 @@ test("out1 changes speed of time as arguments percieve it", () => {
   expect(parse(`do (note 0 7) (out1 (shift 0) (shift 0.5))`)(0, 4)).toEqual(
     parse(`do (note 0 7) (shift 0 0 1 1)`)(0, 4)
   );
+});
+
+test("len changes note lengths", () => {
+  expect(parse(`do (note 0) (len .5)`)(0, 1)).toEqual([
+      { start: 0, end: 1, value: { channel: 0, pitch: 0, length: .5 } }
+  ]);
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -95,6 +95,6 @@ test("out1 changes speed of time as arguments percieve it", () => {
 
 test("len changes note lengths", () => {
   expect(parse(`do (note 0) (len .5)`)(0, 1)).toEqual([
-      { start: 0, end: 1, value: { channel: 0, pitch: 0, length: .5 } }
+    { start: 0, end: 1, value: { channel: 0, pitch: 0, length: 0.5 } }
   ]);
 });

--- a/gallium/src/top_level.test.js
+++ b/gallium/src/top_level.test.js
@@ -74,3 +74,21 @@ test("i is a no-op", () => {
 test("m mutes", () => {
   expect(parse(`do (note 0) m`)(0, 1)).toEqual([]);
 });
+
+test("alt1 switches every two beats", () => {
+  expect(parse(`do (note 0) (alt1 (add 0) (add 7))`)(0, 4)).toEqual(
+    parse(`note 0 0 7 7`)(0, 4)
+  );
+});
+
+test("alt1 does not change speed of time as arguments percieve it", () => {
+  expect(parse(`do (note 0 7) (alt1 (shift 0) (shift 0.5))`)(0, 4)).toEqual(
+    parse(`do (note 0 7) (shift 0 0 .5 .5)`)(0, 4)
+  );
+});
+
+test("out1 changes speed of time as arguments percieve it", () => {
+  expect(parse(`do (note 0 7) (out1 (shift 0) (shift 0.5))`)(0, 4)).toEqual(
+    parse(`do (note 0 7) (shift 0 0 1 1)`)(0, 4)
+  );
+});

--- a/gallium/src/type_checker.js
+++ b/gallium/src/type_checker.js
@@ -8,9 +8,22 @@ type Context = {
   type: Types.Type
 };
 
+export const infer = (node: ABT): Types.Type => {
+  if (node instanceof AST.HApp || node instanceof AST.VApp) {
+    const funType = infer(node.children[0]);
+    return funType.output;
+  }
+  if (node instanceof AST.Paren) {
+    return infer(node.children[0]);
+  }
+  if (node instanceof AST.Name) {
+    return node.data.type;
+  }
+};
+
 export const check = (node: ABT, ctx: Context): void => {
   if (node instanceof AST.HApp || node instanceof AST.VApp) {
-    const funType = node.children[0].data.type;
+    const funType = infer(node.children[0]);
     if (funType.tag === "listProcessor") {
       const outputType = funType.output;
       const inputType = funType.input;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "check-all": "flow check && yarn format-check && yarn test",
       "format": "lerna run format",
       "format-check": "lerna run format-check",
-      "test": "lerna run test"
+      "test": "lerna run test",
+      "start": "(cd gallium-live; yarn run start)"
     }
 }


### PR DESCRIPTION
This PR implements out0-6/in0-6, zoomed in/out alternation combinators that change how time is perceived to its arguments.

This PR also implements alt0-6, slowed alternation helpers that leave time unaffected to its arguments.

---

We also implement len, which affects note length.

---

Closes #106 and #56 